### PR TITLE
mingw: link -static-libgcc -static-libstdc++

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,12 @@ PKG_PROG_PKG_CONFIG
 
 AC_LANG_PUSH([C++])
 
+case $host in
+  *mingw*)
+     LDFLAGS+=" -static-libgcc -static-libstdc++"
+     ;;
+esac
+
 AC_CONFIG_FILES([
     lib/Makefile
     test/Makefile


### PR DESCRIPTION
Seems to work: https://travis-ci.org/bitcoin/bitcoin/builds/81932261

Maybe another git tag after merging this would be required (otherwise we would require to add a non tagged git subtree). Although bumbing version in configure.ac seems not required.
Maybe rename the exiting 1.0.0 tag in 1.0.0RC1 and add a 1.0.0 after merging this PR (ugly force push I know!).