### PR TITLE
build: move libunivalue.la to the root dir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,20 +5,20 @@ ACLOCAL_AMFLAGS = -I build-aux/m4
 include_HEADERS = include/univalue.h
 noinst_HEADERS = lib/univalue_escapes.h
 
-lib_LTLIBRARIES = lib/libunivalue.la
+lib_LTLIBRARIES = libunivalue.la
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = pc/libunivalue.pc
 
-lib_libunivalue_la_SOURCES = \
+libunivalue_la_SOURCES = \
 	lib/univalue.cpp \
 	lib/univalue_read.cpp \
 	lib/univalue_write.cpp
 
-lib_libunivalue_la_LDFLAGS = \
+libunivalue_la_LDFLAGS = \
 	-version-info $(LIBUNIVALUE_CURRENT):$(LIBUNIVALUE_REVISION):$(LIBUNIVALUE_AGE) \
 	-no-undefined
-lib_libunivalue_la_CXXFLAGS = -I$(top_srcdir)/include
+libunivalue_la_CXXFLAGS = -I$(top_srcdir)/include
 
 TESTS = test/unitester
 
@@ -38,7 +38,7 @@ noinst_PROGRAMS = $(TESTS)
 TEST_DATA_DIR=test
 
 test_unitester_SOURCES = test/unitester.cpp
-test_unitester_LDADD = lib/libunivalue.la
+test_unitester_LDADD = libunivalue.la
 test_unitester_CXXFLAGS = -I$(top_srcdir)/include -DJSON_TEST_SRC=\"$(srcdir)/$(TEST_DATA_DIR)\"
 test_unitester_LDFLAGS = -static $(LIBTOOL_APP_LDFLAGS)
 


### PR DESCRIPTION
This will fix the downstream Bitcoin circular dependency, and is arguably cleaner anyway.