### PR TITLE
Do not shadow variables

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -56,7 +56,7 @@ public:
     bool setNumStr(const std::string& val);
     bool setInt(uint64_t val);
     bool setInt(int64_t val);
-    bool setInt(int val) { return setInt((int64_t)val); }
+    bool setInt(int val_) { return setInt((int64_t)val_); }
     bool setFloat(double val);
     bool setStr(const std::string& val);
     bool setArray();
@@ -95,28 +95,28 @@ public:
     bool push_backV(const std::vector<UniValue>& vec);
 
     bool pushKV(const std::string& key, const UniValue& val);
-    bool pushKV(const std::string& key, const std::string& val) {
-        UniValue tmpVal(VSTR, val);
+    bool pushKV(const std::string& key, const std::string& val_) {
+        UniValue tmpVal(VSTR, val_);
         return pushKV(key, tmpVal);
     }
     bool pushKV(const std::string& key, const char *val_) {
-        std::string val(val_);
-        return pushKV(key, val);
+        std::string _val(val_);
+        return pushKV(key, _val);
     }
-    bool pushKV(const std::string& key, int64_t val) {
-        UniValue tmpVal(val);
+    bool pushKV(const std::string& key, int64_t val_) {
+        UniValue tmpVal(val_);
         return pushKV(key, tmpVal);
     }
-    bool pushKV(const std::string& key, uint64_t val) {
-        UniValue tmpVal(val);
+    bool pushKV(const std::string& key, uint64_t val_) {
+        UniValue tmpVal(val_);
         return pushKV(key, tmpVal);
     }
-    bool pushKV(const std::string& key, int val) {
-        UniValue tmpVal((int64_t)val);
+    bool pushKV(const std::string& key, int val_) {
+        UniValue tmpVal((int64_t)val_);
         return pushKV(key, tmpVal);
     }
-    bool pushKV(const std::string& key, double val) {
-        UniValue tmpVal(val);
+    bool pushKV(const std::string& key, double val_) {
+        UniValue tmpVal(val_);
         return pushKV(key, tmpVal);
     }
     bool pushKVs(const UniValue& obj);

--- a/lib/univalue.cpp
+++ b/lib/univalue.cpp
@@ -119,32 +119,32 @@ bool UniValue::setNumStr(const string& val_)
     return true;
 }
 
-bool UniValue::setInt(uint64_t val)
+bool UniValue::setInt(uint64_t val_)
 {
     string s;
     ostringstream oss;
 
-    oss << val;
+    oss << val_;
 
     return setNumStr(oss.str());
 }
 
-bool UniValue::setInt(int64_t val)
+bool UniValue::setInt(int64_t val_)
 {
     string s;
     ostringstream oss;
 
-    oss << val;
+    oss << val_;
 
     return setNumStr(oss.str());
 }
 
-bool UniValue::setFloat(double val)
+bool UniValue::setFloat(double val_)
 {
     string s;
     ostringstream oss;
 
-    oss << std::setprecision(16) << val;
+    oss << std::setprecision(16) << val_;
 
     bool ret = setNumStr(oss.str());
     typ = VNUM;
@@ -173,12 +173,12 @@ bool UniValue::setObject()
     return true;
 }
 
-bool UniValue::push_back(const UniValue& val)
+bool UniValue::push_back(const UniValue& val_)
 {
     if (typ != VARR)
         return false;
 
-    values.push_back(val);
+    values.push_back(val_);
     return true;
 }
 
@@ -192,13 +192,13 @@ bool UniValue::push_backV(const std::vector<UniValue>& vec)
     return true;
 }
 
-bool UniValue::pushKV(const std::string& key, const UniValue& val)
+bool UniValue::pushKV(const std::string& key, const UniValue& val_)
 {
     if (typ != VOBJ)
         return false;
 
     keys.push_back(key);
-    values.push_back(val);
+    values.push_back(val_);
     return true;
 }
 


### PR DESCRIPTION
Preparing Bitcoin Core to be compiled with `-Wshadow`...

This will prevent compiler warnings about variable shadowing. I used the style already used (ie. append underscore).