### PR TITLE
make header style consistent with bitcoin's header style

### DIFF
--- a/gen/gen.cpp
+++ b/gen/gen.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 BitPay Inc.
+// Copyright (c) 2014 BitPay Inc.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/include/univalue.h
+++ b/include/univalue.h
@@ -1,5 +1,5 @@
-// Copyright 2014 BitPay Inc.
-// Copyright 2015 Bitcoin Core Developers
+// Copyright (c) 2014 BitPay Inc.
+// Copyright (c) 2015 Bitcoin Core Developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/lib/univalue.cpp
+++ b/lib/univalue.cpp
@@ -1,5 +1,5 @@
-// Copyright 2014 BitPay Inc.
-// Copyright 2015 Bitcoin Core Developers
+// Copyright (c) 2014 BitPay Inc.
+// Copyright (c) 2015 Bitcoin Core Developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/lib/univalue_read.cpp
+++ b/lib/univalue_read.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 BitPay Inc.
+// Copyright (c) 2014 BitPay Inc.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/lib/univalue_utffilter.h
+++ b/lib/univalue_utffilter.h
@@ -1,4 +1,4 @@
-// Copyright 2016 Wladimir J. van der Laan
+// Copyright (c) 2016 Wladimir J. van der Laan
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef UNIVALUE_UTFFILTER_H

--- a/lib/univalue_write.cpp
+++ b/lib/univalue_write.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 BitPay Inc.
+// Copyright (c) 2014 BitPay Inc.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/test/unitester.cpp
+++ b/test/unitester.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 BitPay Inc.
+// Copyright (c) 2014 BitPay Inc.
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 


### PR DESCRIPTION
Bitcoin's MIT header has a '(c)' after 'Copyright' and this PR applies that style here with a minor adjustment.