### PR TITLE
Convenience wrappers for push_back-ing integer types

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -92,6 +92,18 @@ public:
         std::string s(val_);
         return push_back(s);
     }
+    bool push_back(uint64_t val_) {
+        UniValue tmpVal(val_);
+        return push_back(tmpVal);
+    }
+    bool push_back(int64_t val_) {
+        UniValue tmpVal(val_);
+        return push_back(tmpVal);
+    }
+    bool push_back(int val_) {
+        UniValue tmpVal(val_);
+        return push_back(tmpVal);
+    }
     bool push_backV(const std::vector<UniValue>& vec);
 
     bool pushKV(const std::string& key, const UniValue& val);


### PR DESCRIPTION
These wrappers have been helpful for me.

I don't see an existing hook for unit testing this sort of thing, however, in bitcoin's `src/test/univalue_tests.cpp`, it works with modifications to the test there:

```
BOOST_AUTO_TEST_CASE(univalue_array)
 {
     UniValue arr(UniValue::VARR);

     UniValue v((int64_t)1023LL);
     BOOST_CHECK(arr.push_back(v));

     string vStr("zippy");
     BOOST_CHECK(arr.push_back(vStr));

     const char *s = "pippy";
     BOOST_CHECK(arr.push_back(s));

     vector<UniValue> vec;
     v.setStr("boing");
     vec.push_back(v);

     v.setStr("going");
     vec.push_back(v);

     BOOST_CHECK(arr.push_backV(vec));

+    BOOST_CHECK(arr.push_back((uint64_t)42));
+
+    BOOST_CHECK(arr.push_back((int)-273));
+
+    BOOST_CHECK(arr.push_back((int64_t)-999));
+
     BOOST_CHECK_EQUAL(arr.empty(), false);
-    BOOST_CHECK_EQUAL(arr.size(), 5);
+    BOOST_CHECK_EQUAL(arr.size(), 8);

     BOOST_CHECK_EQUAL(arr[0].getValStr(), "1023");
     BOOST_CHECK_EQUAL(arr[1].getValStr(), "zippy");
     BOOST_CHECK_EQUAL(arr[2].getValStr(), "pippy");
     BOOST_CHECK_EQUAL(arr[3].getValStr(), "boing");
     BOOST_CHECK_EQUAL(arr[4].getValStr(), "going");
+    BOOST_CHECK_EQUAL(arr[5].getValStr(), "42");
+    BOOST_CHECK_EQUAL(arr[6].getValStr(), "-273");
+    BOOST_CHECK_EQUAL(arr[7].getValStr(), "-999");

     BOOST_CHECK_EQUAL(arr[999].getValStr(), "");

     arr.clear();
     BOOST_CHECK(arr.empty());
     BOOST_CHECK_EQUAL(arr.size(), 0);
 }
```
