### PR TITLE
Remove trailing whitespace from JSON export

### DIFF
--- a/lib/univalue_write.cpp
+++ b/lib/univalue_write.cpp
@@ -79,8 +79,6 @@ void UniValue::writeArray(unsigned int prettyIndent, unsigned int indentLevel, s
         s += values[i].write(prettyIndent, indentLevel + 1);
         if (i != (values.size() - 1)) {
             s += ",";
-            if (prettyIndent)
-                s += " ";
         }
         if (prettyIndent)
             s += "\n";


### PR DESCRIPTION
This incorrectly produces a trailing space after `},`

Test case:

``` sh
bitcoin-tx -json -create \
     "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0"\
     "outaddr=0.18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"\
     "outdata=54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"
```

The patch fixes the output in the following way

``` diff
{
    "txid": "c14b007fa3a6c1e7765919c1d14c1cfc2b8642c3a5d3be4b1fa8c4ccfec98bb0",
    "hash": "c14b007fa3a6c1e7765919c1d14c1cfc2b8642c3a5d3be4b1fa8c4ccfec98bb0",
    "version": 2,
    "locktime": 0,
    "vin": [
        {
            "txid": "5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f",
            "vout": 0,
            "scriptSig": {
                "asm": "",
                "hex": ""
            },
            "sequence": 4294967295
        }
    ],
    "vout": [
        {
            "value": 0.18,
            "n": 0,
            "scriptPubKey": {
                "asm": "OP_DUP OP_HASH160 1fc11f39be1729bf973a7ab6a615ca4729d64574 OP_EQUALVERIFY OP_CHECKSIG",
                "hex": "76a9141fc11f39be1729bf973a7ab6a615ca4729d6457488ac",
                "reqSigs": 1,
                "type": "pubkeyhash",
                "addresses": [
                    "13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"
                ]
            }
-        }, 
+        },
        {
            "value": 0.00,
            "n": 1,
            "scriptPubKey": {
                "asm": "OP_RETURN 54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e",
                "hex": "6a4c4f54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e",
                "type": "nulldata"
            }
        }
    ],
    "hex": "02000000011f5c38dfcf6f1a5f5a87c416076d392c87e6d41970d5ad5e477a02d66bde97580000000000ffffffff0280a81201000000001976a9141fc11f39be1729bf973a7ab6a615ca4729d6457488ac0000000000000000526a4c4f54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e00000000"
}
```
