### PR TITLE
Use size_t for UniValue array indexing

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -25,6 +25,9 @@ public:
         typ = initialType;
         val = initialStr;
     }
+    UniValue(size_t val_) {
+        setInt(val_);
+    }
     UniValue(uint64_t val_) {
         setInt(val_);
     }
@@ -54,6 +57,7 @@ public:
     bool setNull();
     bool setBool(bool val);
     bool setNumStr(const std::string& val);
+    bool setInt(size_t val_);
     bool setInt(uint64_t val);
     bool setInt(int64_t val);
     bool setInt(int val_) { return setInt((int64_t)val_); }
@@ -91,6 +95,10 @@ public:
     bool push_back(const char *val_) {
         std::string s(val_);
         return push_back(s);
+    }
+    bool push_back(size_t val_) {
+        UniValue tmpVal(val_);
+        return push_back(tmpVal);
     }
     bool push_back(uint64_t val_) {
         UniValue tmpVal(val_);
@@ -187,6 +195,13 @@ static inline std::pair<std::string,UniValue> Pair(const char *cKey, std::string
 {
     std::string key(cKey);
     UniValue uVal(strVal);
+    return std::make_pair(key, uVal);
+}
+
+static inline std::pair<std::string,UniValue> Pair(const char *cKey, size_t sizeVal)
+{
+    std::string key(cKey);
+    UniValue uVal(sizeVal);
     return std::make_pair(key, uVal);
 }
 

--- a/include/univalue.h
+++ b/include/univalue.h
@@ -71,8 +71,8 @@ public:
     bool getBool() const { return isTrue(); }
     bool checkObject(const std::map<std::string,UniValue::VType>& memberTypes);
     const UniValue& operator[](const std::string& key) const;
-    const UniValue& operator[](unsigned int index) const;
-    bool exists(const std::string& key) const { return (findKey(key) >= 0); }
+    const UniValue& operator[](size_t index) const;
+    bool exists(const std::string& key) const { size_t i; return findKey(key, i); }
 
     bool isNull() const { return (typ == VNULL); }
     bool isTrue() const { return (typ == VBOOL) && (val == "1"); }
@@ -148,7 +148,7 @@ private:
     std::vector<std::string> keys;
     std::vector<UniValue> values;
 
-    int findKey(const std::string& key) const;
+    bool findKey(const std::string& key, size_t& ret) const;
     void writeArray(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const;
     void writeObject(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const;
 

--- a/lib/univalue.cpp
+++ b/lib/univalue.cpp
@@ -119,6 +119,15 @@ bool UniValue::setNumStr(const string& val_)
     return true;
 }
 
+bool UniValue::setInt(size_t val_)
+{
+    ostringstream oss;
+
+    oss << val_;
+
+    return setNumStr(oss.str());
+}
+
 bool UniValue::setInt(uint64_t val_)
 {
     ostringstream oss;

--- a/lib/univalue.cpp
+++ b/lib/univalue.cpp
@@ -212,22 +212,24 @@ bool UniValue::pushKVs(const UniValue& obj)
     return true;
 }
 
-int UniValue::findKey(const std::string& key) const
+bool UniValue::findKey(const std::string& key, size_t& ret) const
 {
-    for (unsigned int i = 0; i < keys.size(); i++) {
-        if (keys[i] == key)
-            return (int) i;
+    for (size_t i = 0; i < keys.size(); i++) {
+        if (keys[i] == key) {
+            ret = i;
+            return true;
+        }
     }
 
-    return -1;
+    return false;
 }
 
 bool UniValue::checkObject(const std::map<std::string,UniValue::VType>& t)
 {
     for (std::map<std::string,UniValue::VType>::const_iterator it = t.begin();
          it != t.end(); ++it) {
-        int idx = findKey(it->first);
-        if (idx < 0)
+        size_t idx;
+        if (!findKey(it->first, idx))
             return false;
 
         if (values.at(idx).getType() != it->second)
@@ -242,14 +244,14 @@ const UniValue& UniValue::operator[](const std::string& key) const
     if (typ != VOBJ)
         return NullUniValue;
 
-    int index = findKey(key);
-    if (index < 0)
+    size_t index;
+    if (!findKey(key, index))
         return NullUniValue;
 
     return values.at(index);
 }
 
-const UniValue& UniValue::operator[](unsigned int index) const
+const UniValue& UniValue::operator[](size_t index) const
 {
     if (typ != VOBJ && typ != VARR)
         return NullUniValue;


### PR DESCRIPTION
Resolves potentially security-relevant integer overflow bugs:
- On LLP64 platforms (Windows), the code will overflow for indices >= 2^32
- On Linux, `unsigned int` is smaller than `size_t`

Also fixes some MacOS compile issues when trying to create values from `size_t`.