### PR TITLE
Reject unterminated strings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -88,6 +88,7 @@ TEST_FILES = \
 	$(TEST_DATA_DIR)/fail40.json \
 	$(TEST_DATA_DIR)/fail41.json \
 	$(TEST_DATA_DIR)/fail42.json \
+	$(TEST_DATA_DIR)/fail44.json \
 	$(TEST_DATA_DIR)/fail3.json \
 	$(TEST_DATA_DIR)/fail4.json \
 	$(TEST_DATA_DIR)/fail5.json \

--- a/lib/univalue_read.cpp
+++ b/lib/univalue_read.cpp
@@ -177,8 +177,8 @@ enum jtokentype getJsonToken(string& tokenVal, unsigned int& consumed,
         string valStr;
         JSONUTF8StringFilter writer(valStr);
 
-        while (raw < end) {
-            if ((unsigned char)*raw < 0x20)
+        while (true) {
+            if (raw >= end || (unsigned char)*raw < 0x20)
                 return JTOK_ERR;
 
             else if (*raw == '\\') {

--- a/test/fail44.json
+++ b/test/fail44.json
@@ -1,0 +1,1 @@
+"This file ends without a newline or close-quote.

--- a/test/unitester.cpp
+++ b/test/unitester.cpp
@@ -114,6 +114,7 @@ static const char *filenames[] = {
         "fail40.json",               // invalid unicode: broken UTF-8
         "fail41.json",               // invalid unicode: unfinished UTF-8
         "fail42.json",               // valid json with garbage following a nul byte
+        "fail44.json",               // unterminated string
         "fail3.json",
         "fail4.json",                // extra comma
         "fail5.json",


### PR DESCRIPTION
Fixes following test failures in https://github.com/nst/JSONTestSuite:

bitcoin SHOULD_HAVE_FAILED  n_string_single_doublequote.json