### PR TITLE
Declare single-argument (non-converting) constructors "explicit"

### DIFF
--- a/lib/univalue_utffilter.h
+++ b/lib/univalue_utffilter.h
@@ -13,7 +13,7 @@
 class JSONUTF8StringFilter
 {
 public:
-    JSONUTF8StringFilter(std::string &s):
+    explicit JSONUTF8StringFilter(std::string &s):
         str(s), is_valid(true), codepoint(0), state(0), surpair(0)
     {
     }


### PR DESCRIPTION
In order to avoid unintended implicit conversions.

Closes #43 