### PR TITLE
Cleaned up namespace imports to reduce symbol collisions

### DIFF
--- a/gen/gen.cpp
+++ b/gen/gen.cpp
@@ -12,8 +12,6 @@
 #include <string.h>
 #include "univalue.h"
 
-using namespace std;
-
 static bool initEscapes;
 static std::string escapes[256];
 

--- a/lib/univalue.cpp
+++ b/lib/univalue.cpp
@@ -10,8 +10,6 @@
 
 #include "univalue.h"
 
-using namespace std;
-
 const UniValue NullUniValue;
 
 void UniValue::clear()
@@ -37,15 +35,15 @@ bool UniValue::setBool(bool val_)
     return true;
 }
 
-static bool validNumStr(const string& s)
+static bool validNumStr(const std::string& s)
 {
-    string tokenVal;
+    std::string tokenVal;
     unsigned int consumed;
     enum jtokentype tt = getJsonToken(tokenVal, consumed, s.data(), s.data() + s.size());
     return (tt == JTOK_NUMBER);
 }
 
-bool UniValue::setNumStr(const string& val_)
+bool UniValue::setNumStr(const std::string& val_)
 {
     if (!validNumStr(val_))
         return false;
@@ -58,7 +56,7 @@ bool UniValue::setNumStr(const string& val_)
 
 bool UniValue::setInt(uint64_t val_)
 {
-    ostringstream oss;
+    std::ostringstream oss;
 
     oss << val_;
 
@@ -67,7 +65,7 @@ bool UniValue::setInt(uint64_t val_)
 
 bool UniValue::setInt(int64_t val_)
 {
-    ostringstream oss;
+    std::ostringstream oss;
 
     oss << val_;
 
@@ -76,7 +74,7 @@ bool UniValue::setInt(int64_t val_)
 
 bool UniValue::setFloat(double val_)
 {
-    ostringstream oss;
+    std::ostringstream oss;
 
     oss << std::setprecision(16) << val_;
 
@@ -85,7 +83,7 @@ bool UniValue::setFloat(double val_)
     return ret;
 }
 
-bool UniValue::setStr(const string& val_)
+bool UniValue::setStr(const std::string& val_)
 {
     clear();
     typ = VSTR;

--- a/lib/univalue_read.cpp
+++ b/lib/univalue_read.cpp
@@ -8,8 +8,6 @@
 #include "univalue.h"
 #include "univalue_utffilter.h"
 
-using namespace std;
-
 static bool json_isdigit(int ch)
 {
     return ((ch >= '0') && (ch <= '9'));
@@ -42,7 +40,7 @@ static const char *hatoui(const char *first, const char *last,
     return first;
 }
 
-enum jtokentype getJsonToken(string& tokenVal, unsigned int& consumed,
+enum jtokentype getJsonToken(std::string& tokenVal, unsigned int& consumed,
                             const char *raw, const char *end)
 {
     tokenVal.clear();
@@ -114,7 +112,7 @@ enum jtokentype getJsonToken(string& tokenVal, unsigned int& consumed,
     case '8':
     case '9': {
         // part 1: int
-        string numStr;
+        std::string numStr;
 
         const char *first = raw;
 
@@ -174,7 +172,7 @@ enum jtokentype getJsonToken(string& tokenVal, unsigned int& consumed,
     case '"': {
         raw++;                                // skip "
 
-        string valStr;
+        std::string valStr;
         JSONUTF8StringFilter writer(valStr);
 
         while (true) {
@@ -255,9 +253,9 @@ bool UniValue::read(const char *raw, size_t size)
     clear();
 
     uint32_t expectMask = 0;
-    vector<UniValue*> stack;
+    std::vector<UniValue*> stack;
 
-    string tokenVal;
+    std::string tokenVal;
     unsigned int consumed;
     enum jtokentype tok = JTOK_NONE;
     enum jtokentype last_tok = JTOK_NONE;

--- a/lib/univalue_write.cpp
+++ b/lib/univalue_write.cpp
@@ -8,11 +8,9 @@
 #include "univalue.h"
 #include "univalue_escapes.h"
 
-using namespace std;
-
-static string json_escape(const string& inS)
+static std::string json_escape(const std::string& inS)
 {
-    string outS;
+    std::string outS;
     outS.reserve(inS.size() * 2);
 
     for (unsigned int i = 0; i < inS.size(); i++) {
@@ -28,10 +26,10 @@ static string json_escape(const string& inS)
     return outS;
 }
 
-string UniValue::write(unsigned int prettyIndent,
-                       unsigned int indentLevel) const
+std::string UniValue::write(unsigned int prettyIndent,
+                            unsigned int indentLevel) const
 {
-    string s;
+    std::string s;
     s.reserve(1024);
 
     unsigned int modIndent = indentLevel;
@@ -62,12 +60,12 @@ string UniValue::write(unsigned int prettyIndent,
     return s;
 }
 
-static void indentStr(unsigned int prettyIndent, unsigned int indentLevel, string& s)
+static void indentStr(unsigned int prettyIndent, unsigned int indentLevel, std::string& s)
 {
     s.append(prettyIndent * indentLevel, ' ');
 }
 
-void UniValue::writeArray(unsigned int prettyIndent, unsigned int indentLevel, string& s) const
+void UniValue::writeArray(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const
 {
     s += "[";
     if (prettyIndent)
@@ -89,7 +87,7 @@ void UniValue::writeArray(unsigned int prettyIndent, unsigned int indentLevel, s
     s += "]";
 }
 
-void UniValue::writeObject(unsigned int prettyIndent, unsigned int indentLevel, string& s) const
+void UniValue::writeObject(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const
 {
     s += "{";
     if (prettyIndent)

--- a/test/unitester.cpp
+++ b/test/unitester.cpp
@@ -17,8 +17,7 @@
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 #endif
 
-using namespace std;
-string srcdir(JSON_TEST_SRC);
+std::string srcdir(JSON_TEST_SRC);
 static bool test_failed = false;
 
 #define d_assert(expr) { if (!(expr)) { test_failed = true; fprintf(stderr, "%s failed\n", filename.c_str()); } }
@@ -30,9 +29,9 @@ static std::string rtrim(std::string s)
     return s;
 }
 
-static void runtest(string filename, const string& jdata)
+static void runtest(std::string filename, const std::string& jdata)
 {
-        string prefix = filename.substr(0, 4);
+        std::string prefix = filename.substr(0, 4);
 
         bool wantPass = (prefix == "pass") || (prefix == "roun");
         bool wantFail = (prefix == "fail");
@@ -56,19 +55,19 @@ static void runtest(string filename, const string& jdata)
 
 static void runtest_file(const char *filename_)
 {
-        string basename(filename_);
-        string filename = srcdir + "/" + basename;
+        std::string basename(filename_);
+        std::string filename = srcdir + "/" + basename;
         FILE *f = fopen(filename.c_str(), "r");
         assert(f != NULL);
 
-        string jdata;
+        std::string jdata;
 
         char buf[4096];
         while (!feof(f)) {
                 int bread = fread(buf, 1, sizeof(buf), f);
                 assert(!ferror(f));
 
-                string s(buf, bread);
+                std::string s(buf, bread);
                 jdata += s;
         }
 


### PR DESCRIPTION
Remove namespace imports as they pollute namespace and are prone to symbol clashes.