### PR TITLE
Remove unnecessary sstream header from univalue.h

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -14,7 +14,6 @@
 #include <map>
 #include <cassert>
 
-#include <sstream>        // .get_int64()
 #include <utility>        // std::pair
 
 class UniValue {

--- a/lib/univalue_get.cpp
+++ b/lib/univalue_get.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include <limits>
 #include <string>
+#include <sstream>
 
 #include "univalue.h"
 


### PR DESCRIPTION
sstream is not needed in the header. If there needs to be stream objects as
member variables of classes, header iosfwd should be included to make
the compilation time of the dependant headers faster by removing
unnecessary preprocessing.