### PR TITLE
Avoid names starting with double underscore

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#ifndef __UNIVALUE_H__
-#define __UNIVALUE_H__
+#ifndef UNIVALUE_H_
+#define UNIVALUE_H_
 
 #include <stdint.h>
 #include <string.h>
@@ -90,7 +90,7 @@ public:
     bool push_back(const UniValue& val);
     bool push_backV(const std::vector<UniValue>& vec);
 
-    void __pushKV(const std::string& key, const UniValue& val);
+    void _pushKV(const std::string& key, const UniValue& val);
     bool pushKV(const std::string& key, const UniValue& val);
     bool pushKVs(const UniValue& obj);
 
@@ -187,4 +187,4 @@ extern const UniValue NullUniValue;
 
 const UniValue& find_value( const UniValue& obj, const std::string& name);
 
-#endif // __UNIVALUE_H__
+#endif // UNIVALUE_H_

--- a/lib/univalue.cpp
+++ b/lib/univalue.cpp
@@ -124,7 +124,7 @@ bool UniValue::push_backV(const std::vector<UniValue>& vec)
     return true;
 }
 
-void UniValue::__pushKV(const std::string& key, const UniValue& val_)
+void UniValue::_pushKV(const std::string& key, const UniValue& val_)
 {
     keys.push_back(key);
     values.push_back(val_);
@@ -139,7 +139,7 @@ bool UniValue::pushKV(const std::string& key, const UniValue& val_)
     if (findKey(key, idx))
         values[idx] = val_;
     else
-        __pushKV(key, val_);
+        _pushKV(key, val_);
     return true;
 }
 
@@ -149,7 +149,7 @@ bool UniValue::pushKVs(const UniValue& obj)
         return false;
 
     for (size_t i = 0; i < obj.keys.size(); i++)
-        __pushKV(obj.keys[i], obj.values.at(i));
+        _pushKV(obj.keys[i], obj.values.at(i));
 
     return true;
 }

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE(univalue_object)
     BOOST_CHECK_EQUAL(obj.setObject(), true);
     UniValue uv;
     uv.setInt(42);
-    obj.__pushKV("age", uv);
+    obj._pushKV("age", uv);
     BOOST_CHECK_EQUAL(obj.size(), 1);
     BOOST_CHECK_EQUAL(obj["age"].getValStr(), "42");
 


### PR DESCRIPTION
These are reserved for all uses (including member function names) in C++, and their use is technically undefined behaviour: https://stackoverflow.com/a/228797/393146

Signed-off-by: Daira Hopwood <daira@jacaranda.org>