### PR TITLE
add removeKey method

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -93,6 +93,7 @@ public:
     void __pushKV(const std::string& key, const UniValue& val);
     bool pushKV(const std::string& key, const UniValue& val);
     bool pushKVs(const UniValue& obj);
+    bool removeKey(const std::string& key);
 
     std::string write(unsigned int prettyIndent = 0,
                       unsigned int indentLevel = 0) const;

--- a/lib/univalue.cpp
+++ b/lib/univalue.cpp
@@ -154,6 +154,15 @@ bool UniValue::pushKVs(const UniValue& obj)
     return true;
 }
 
+bool UniValue::removeKey(const std::string& key)
+{
+    size_t idx;
+    if (typ != VOBJ || !findKey(key, idx)) return false;
+    keys.erase(keys.begin() + idx);
+    values.erase(values.begin() + idx);
+    return true;
+}
+
 void UniValue::getObjMap(std::map<std::string,UniValue>& kv) const
 {
     if (typ != VOBJ)

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -350,6 +350,34 @@ BOOST_AUTO_TEST_CASE(univalue_object)
     BOOST_CHECK_EQUAL(kv["age"].getValStr(), "43");
     BOOST_CHECK_EQUAL(kv["name"].getValStr(), "foo bar");
 
+    obj = UniValue(UniValue::VOBJ);
+    BOOST_CHECK_EQUAL(obj.size(), 0);
+    BOOST_CHECK_EQUAL(obj.removeKey("unknownkey"), false);
+    BOOST_CHECK_EQUAL(obj.size(), 0);
+    obj.pushKV("age", uv);
+    BOOST_CHECK_EQUAL(obj.size(), 1);
+    BOOST_CHECK_EQUAL(obj["age"].getValStr(), "43");
+    BOOST_CHECK_EQUAL(obj.removeKey("unknownkey"), false);
+    BOOST_CHECK_EQUAL(obj.size(), 1);
+    BOOST_CHECK_EQUAL(obj.removeKey("age"), true);
+    BOOST_CHECK_EQUAL(obj.size(), 0);
+    BOOST_CHECK_EQUAL(obj.removeKey("age"), false);
+    obj.pushKV("age", uv);
+    obj.pushKV("name", "foo bar");
+    BOOST_CHECK_EQUAL(obj.removeKey("unknownkey"), false);
+    BOOST_CHECK_EQUAL(obj.size(), 2);
+    BOOST_CHECK_EQUAL(obj["age"].getValStr(), "43");
+    BOOST_CHECK_EQUAL(obj["name"].getValStr(), "foo bar");
+    BOOST_CHECK_EQUAL(obj.removeKey("age"), true);
+    BOOST_CHECK_EQUAL(obj.size(), 1);
+    BOOST_CHECK_EQUAL(obj["name"].getValStr(), "foo bar");
+    BOOST_CHECK_EQUAL(obj.removeKey("name"), true);
+    BOOST_CHECK_EQUAL(obj.size(), 0);
+    obj.pushKV("age", uv);
+    obj.pushKV("name", "foo bar");
+    BOOST_CHECK_EQUAL(obj.removeKey("name"), true);
+    BOOST_CHECK_EQUAL(obj.size(), 1);
+    BOOST_CHECK_EQUAL(obj["age"].getValStr(), "43");
 }
 
 static const char *json1 =


### PR DESCRIPTION
This introduces a `removeKey` method for object types, which would be useful when handling alias-cases, since currently there is no way to "move" a value. (A `renameKey` method would be ideal, but that seems a bit too specialized.)

See https://github.com/bitcoin/bitcoin/pull/19957.