### PR TITLE
univalue optimizations: move semantics, reduce temporary strings

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -20,6 +20,7 @@ public:
 
     UniValue() : typ(VNULL) {}
     UniValue(UniValue::VType type, const std::string& value = std::string()) : typ(type), val(value) {}
+    UniValue(UniValue::VType type, std::string&& value) : typ(type), val(std::move(value)) {}
     UniValue(uint64_t val_) {
         setInt(val_);
     }
@@ -38,9 +39,11 @@ public:
     UniValue(const std::string& val_) {
         setStr(val_);
     }
+    UniValue(std::string&& val_) {
+        setStr(std::move(val_));
+    }
     UniValue(const char *val_) {
-        std::string s(val_);
-        setStr(s);
+        setStr(std::string(val_));
     }
 
     void clear();
@@ -57,11 +60,13 @@ public:
     bool setNull();
     bool setBool(bool val);
     bool setNumStr(const std::string& val);
+    bool setNumStr(std::string&& val);
     bool setInt(uint64_t val);
     bool setInt(int64_t val);
     bool setInt(int val_) { return setInt((int64_t)val_); }
     bool setFloat(double val);
     bool setStr(const std::string& val);
+    bool setStr(std::string&& val);
     bool setArray();
     bool setObject();
 
@@ -88,11 +93,22 @@ public:
     bool isObject() const { return (typ == VOBJ); }
 
     bool push_back(const UniValue& val);
+    bool push_back(UniValue&& val);
     bool push_backV(const std::vector<UniValue>& vec);
+    bool push_backV(std::vector<UniValue>&& vec);
 
     void __pushKV(const std::string& key, const UniValue& val);
+    void __pushKV(const std::string& key, UniValue&& val);
+    void __pushKV(std::string&& key, const UniValue& val);
+    void __pushKV(std::string&& key, UniValue&& val);
+
     bool pushKV(const std::string& key, const UniValue& val);
+    bool pushKV(const std::string& key, UniValue&& val);
+    bool pushKV(std::string&& key, const UniValue& val);
+    bool pushKV(std::string&& key, UniValue&& val);
+
     bool pushKVs(const UniValue& obj);
+    bool pushKVs(UniValue&& obj);
 
     std::string write(unsigned int prettyIndent = 0,
                       unsigned int indentLevel = 0) const;
@@ -110,6 +126,7 @@ private:
     std::vector<UniValue> values;
 
     bool findKey(const std::string& key, size_t& retIdx) const;
+    void write(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const;
     void writeArray(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const;
     void writeObject(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const;
 

--- a/lib/univalue_read.cpp
+++ b/lib/univalue_read.cpp
@@ -172,7 +172,7 @@ enum jtokentype getJsonToken(std::string& tokenVal, unsigned int& consumed,
             }
         }
 
-        tokenVal = numStr;
+        tokenVal = std::move(numStr);
         consumed = (raw - rawStart);
         return JTOK_NUMBER;
         }
@@ -234,7 +234,7 @@ enum jtokentype getJsonToken(std::string& tokenVal, unsigned int& consumed,
 
         if (!writer.finalize())
             return JTOK_ERR;
-        tokenVal = valStr;
+        tokenVal = std::move(valStr);
         consumed = (raw - rawStart);
         return JTOK_STRING;
         }
@@ -325,7 +325,7 @@ bool UniValue::read(const char *raw, size_t size)
             } else {
                 UniValue tmpVal(utyp);
                 UniValue *top = stack.back();
-                top->values.push_back(tmpVal);
+                top->values.push_back(std::move(tmpVal));
 
                 UniValue *newTop = &(top->values.back());
                 stack.push_back(newTop);
@@ -400,12 +400,12 @@ bool UniValue::read(const char *raw, size_t size)
             }
 
             if (!stack.size()) {
-                *this = tmpVal;
+                *this = std::move(tmpVal);
                 break;
             }
 
             UniValue *top = stack.back();
-            top->values.push_back(tmpVal);
+            top->values.push_back(std::move(tmpVal));
 
             setExpect(NOT_VALUE);
             break;
@@ -414,12 +414,12 @@ bool UniValue::read(const char *raw, size_t size)
         case JTOK_NUMBER: {
             UniValue tmpVal(VNUM, tokenVal);
             if (!stack.size()) {
-                *this = tmpVal;
+                *this = std::move(tmpVal);
                 break;
             }
 
             UniValue *top = stack.back();
-            top->values.push_back(tmpVal);
+            top->values.push_back(std::move(tmpVal));
 
             setExpect(NOT_VALUE);
             break;
@@ -434,11 +434,11 @@ bool UniValue::read(const char *raw, size_t size)
             } else {
                 UniValue tmpVal(VSTR, tokenVal);
                 if (!stack.size()) {
-                    *this = tmpVal;
+                    *this = std::move(tmpVal);
                     break;
                 }
                 UniValue *top = stack.back();
-                top->values.push_back(tmpVal);
+                top->values.push_back(std::move(tmpVal));
             }
 
             setExpect(NOT_VALUE);

--- a/lib/univalue_write.cpp
+++ b/lib/univalue_write.cpp
@@ -47,9 +47,9 @@ void UniValue::write(unsigned int prettyIndent,
         writeArray(prettyIndent, modIndent, s);
         break;
     case VSTR:
-        s += "\"";
+        s += '"';
         json_escape(val, s);
-        s += "\"";
+        s += '"';
         break;
     case VNUM:
         s += val;
@@ -67,49 +67,49 @@ static void indentStr(unsigned int prettyIndent, unsigned int indentLevel, std::
 
 void UniValue::writeArray(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const
 {
-    s += "[";
+    s += '[';
     if (prettyIndent)
-        s += "\n";
+        s += '\n';
 
     for (unsigned int i = 0; i < values.size(); i++) {
         if (prettyIndent)
             indentStr(prettyIndent, indentLevel, s);
         values[i].write(prettyIndent, indentLevel + 1, s);
         if (i != (values.size() - 1)) {
-            s += ",";
+            s += ',';
         }
         if (prettyIndent)
-            s += "\n";
+            s += '\n';
     }
 
     if (prettyIndent)
         indentStr(prettyIndent, indentLevel - 1, s);
-    s += "]";
+    s += ']';
 }
 
 void UniValue::writeObject(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const
 {
-    s += "{";
+    s += '{';
     if (prettyIndent)
-        s += "\n";
+        s += '\n';
 
     for (unsigned int i = 0; i < keys.size(); i++) {
         if (prettyIndent)
             indentStr(prettyIndent, indentLevel, s);
-        s += "\"";
+        s += '\"';
         json_escape(keys[i], s);
         s += "\":";
         if (prettyIndent)
-            s += " ";
+            s += ' ';
         values.at(i).write(prettyIndent, indentLevel + 1, s);
         if (i != (values.size() - 1))
-            s += ",";
+            s += ',';
         if (prettyIndent)
-            s += "\n";
+            s += '\n';
     }
 
     if (prettyIndent)
         indentStr(prettyIndent, indentLevel - 1, s);
-    s += "}";
+    s += '}';
 }
 


### PR DESCRIPTION
* Introducing move semantics for pushKV and push_back. In many use cases
  the const& calls unnecessarily create a copy of the argument, when
  objects can be moved this does not happen.

* Reduce creation of temporary strings. `json_escape` and `write` now
  appends to an existing string instead of creating a temporary.

* Use `std::to_string` instead of `std::ostringstream` for `setNumStr`,
  which is much faster than creating a temporary string.

In a benchmark with Bitcoin's BlockToJsonVerbose, using these move
methods where possible speeds up JSON generation by about a factor of 2.

You can see some benchmarks here: https://github.com/bitcoin/bitcoin/pull/20999