### PR TITLE
[1.0.x] Push bool into array correctly

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -101,6 +101,10 @@ public:
         UniValue tmpVal(val_);
         return push_back(tmpVal);
     }
+    bool push_back(bool val_) {
+        UniValue tmpVal(val_);
+        return push_back(tmpVal);
+    }
     bool push_back(int val_) {
         UniValue tmpVal(val_);
         return push_back(tmpVal);
@@ -130,7 +134,7 @@ public:
         return pushKV(key, tmpVal);
     }
     bool pushKV(const std::string& key, bool val_) {
-        UniValue tmpVal((bool)val_);
+        UniValue tmpVal(val_);
         return pushKV(key, tmpVal);
     }
     bool pushKV(const std::string& key, int val_) {

--- a/lib/univalue_get.cpp
+++ b/lib/univalue_get.cpp
@@ -35,7 +35,7 @@ bool ParseInt32(const std::string& str, int32_t *out)
     errno = 0; // strtol will not set errno if valid
     long int n = strtol(str.c_str(), &endp, 10);
     if(out) *out = (int32_t)n;
-    // Note that strtol returns a *long int*, so even if strtol doesn't report a over/underflow
+    // Note that strtol returns a *long int*, so even if strtol doesn't report an over/underflow
     // we still have to check that the returned value is within the range of an *int32_t*. On 64-bit
     // platforms the size of these types may be different.
     return endp && *endp == 0 && !errno &&

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -210,19 +210,31 @@ BOOST_AUTO_TEST_CASE(univalue_array)
     BOOST_CHECK(arr.push_back((int64_t) -400LL));
     BOOST_CHECK(arr.push_back((int) -401));
     BOOST_CHECK(arr.push_back(-40.1));
+    BOOST_CHECK(arr.push_back(true));
 
     BOOST_CHECK_EQUAL(arr.empty(), false);
-    BOOST_CHECK_EQUAL(arr.size(), 9);
+    BOOST_CHECK_EQUAL(arr.size(), 10);
 
     BOOST_CHECK_EQUAL(arr[0].getValStr(), "1023");
+    BOOST_CHECK_EQUAL(arr[0].getType(), UniValue::VNUM);
     BOOST_CHECK_EQUAL(arr[1].getValStr(), "zippy");
+    BOOST_CHECK_EQUAL(arr[1].getType(), UniValue::VSTR);
     BOOST_CHECK_EQUAL(arr[2].getValStr(), "pippy");
+    BOOST_CHECK_EQUAL(arr[2].getType(), UniValue::VSTR);
     BOOST_CHECK_EQUAL(arr[3].getValStr(), "boing");
+    BOOST_CHECK_EQUAL(arr[3].getType(), UniValue::VSTR);
     BOOST_CHECK_EQUAL(arr[4].getValStr(), "going");
+    BOOST_CHECK_EQUAL(arr[4].getType(), UniValue::VSTR);
     BOOST_CHECK_EQUAL(arr[5].getValStr(), "400");
+    BOOST_CHECK_EQUAL(arr[5].getType(), UniValue::VNUM);
     BOOST_CHECK_EQUAL(arr[6].getValStr(), "-400");
+    BOOST_CHECK_EQUAL(arr[6].getType(), UniValue::VNUM);
     BOOST_CHECK_EQUAL(arr[7].getValStr(), "-401");
+    BOOST_CHECK_EQUAL(arr[7].getType(), UniValue::VNUM);
     BOOST_CHECK_EQUAL(arr[8].getValStr(), "-40.1");
+    BOOST_CHECK_EQUAL(arr[8].getType(), UniValue::VNUM);
+    BOOST_CHECK_EQUAL(arr[9].getValStr(), "1");
+    BOOST_CHECK_EQUAL(arr[9].getType(), UniValue::VBOOL);
 
     BOOST_CHECK_EQUAL(arr[999].getValStr(), "");
 


### PR DESCRIPTION
Currently, 1.0.5 will turn a `bool` into a JSON Number when using `push_back`.

master doesn't have this problem due to #61, though it may need to be kept in mind when fixing #76

(Also includes a typo fix)