### PR TITLE
Remove hand-coded UniValue destructor.

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -47,7 +47,6 @@ public:
         std::string s(val_);
         setStr(s);
     }
-    ~UniValue() {}
 
     void clear();
 


### PR DESCRIPTION
When the hand-written destructor is removed, the compiler will automatically create a proper one, with correct `noexcept`. This allows `std::vector<UniValue>` to be resized without having to copy all elements first, which makes JSON generation of a bitcoin block (as in the benchmark "BlockToJsonVerbose") 25% faster on my machine.

(Clean merge to both stable-1.0.x and master)